### PR TITLE
Add a a fallback "en" translation

### DIFF
--- a/nymea-app/translations/nymea-app-en.ts
+++ b/nymea-app/translations/nymea-app-en.ts
@@ -1,0 +1,4102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>AboutNymeaPage</name>
+    <message>
+        <source>About %1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connection:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server UUID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JSON-RPC version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AboutPage</name>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Qt version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AppLogPage</name>
+    <message>
+        <source>App log</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AppSettingsPage</name>
+    <message>
+        <source>App Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Look &amp; feel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize the app&apos;s look and behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloud login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Developer options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeehaaa!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find app versions and licence information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log into %1:cloud and manage connected %1:core systems</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AwningDeviceListPage</name>
+    <message>
+        <source>Awnings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlindDeviceListPage</name>
+    <message>
+        <source>Blinds</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothDevice</name>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnecting from %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discovering services of %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 connected and discovered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 disconnected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothDiscoveryPage</name>
+    <message>
+        <source>Wireless Box setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uh oh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bluetooth doesn&apos;t seem to be available on this device. The wireless network setup requires a working Bluetooth connection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bluetooth seems to be disabled. Please enable Bluetooth on your device in order to use the wireless network setup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless setup help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>After having installed the nymea community image to your Raspberry Pi, all you need to do is to plug it into a power socket. Note that the Wireless setup will only be available if the Raspberry Pi is not connected to a wired network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you have a %1 box, plug it into a power socket and wait for it to be booted. Once the LED pulses slowly, press the button for 3 seconds until the LED changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching for %1:core systems.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Troubles finding your %1:core?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 box</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BoxInfoPage</name>
+    <message>
+        <source>Box information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System UUID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Software revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Firmware revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BrowserContextMenu</name>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CalendarItemDelegate</name>
+    <message>
+        <source>From %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>repeated %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hourly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>daily</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fri</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>weekly on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>monthly on the %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>every year</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CertificateDialog</name>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hi there!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fingerprint: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to connect nevertheless?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to trust this device?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The certificate of this %1:core has changed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems this is the first time you connect to this %1:core.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Did you change the system&apos;s configuration? Verify if this information is correct.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is the certificate for this %1:core. Once you trust it, an encrypted connection will be established.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CloudLoginPage</name>
+    <message numerus="yes">
+        <source>There are %n boxes connected to your cloud</source>
+        <translation type="obsolete">
+            <numerusform>There is %n box connected to your cloud.</numerusform>
+            <numerusform>There are %n boxes connected to your cloud.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>There are %n boxes connected to your cloud.</source>
+        <translation type="vanished">
+            <numerusform>There is %n box connected to your cloud.</numerusform>
+            <numerusform>There are %n boxes connected to your cloud.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Cloud login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, an error happened removing the account. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logged in as %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Goodbye</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete my account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>See our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt; to find out what information is processed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to log in. Please try again. Do you perhaps have &lt;a href=&quot;#&quot;&gt;forgotten your password?&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t have a user yet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sign Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sign up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Welcome to %1:cloud.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please enter your email address and pick a password in order to create a new account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>See our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt; to find out what information is processed. By signing up to %2:cloud you accept those terms and conditions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The given username or password are not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uh oh, something went wrong. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirm account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thanks for signing up. We will send you an email with a confirmation code. Please enter that code in the field below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The given user already exists. Did you forget the password?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>That wasn&apos;t the right code. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, this wasn&apos;t right. Did you misspell the email address?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, there were too many attempts. Please try again after some time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password forgotten?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No problem. Enter your email address here and we&apos;ll send you a confirmation code to change your password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, couldn&apos;t reset your password. Did you enter the wrong confirmation code?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yay!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your password has been reset.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check your email!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter the confirmation code you&apos;ve received and a new password for your user %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirmation code:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick a new password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no %1:core systems connected to your cloud yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>There are %n %1:core systems connected to your cloud.</source>
+        <translation>
+            <numerusform>There is %n %1:core system connected to your cloud.</numerusform>
+            <numerusform>There are %n %1:core systems connected to your cloud.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Sorry to see you go. If you log out you won&apos;t be able to connect to %1:core systems remotely any more. However, you can come back any time, we&apos;ll keep your user account. If you whish to completely delete your account and all the data associated with it, check the box below before hitting ok. If you decide to delete your account, all your personal information will be removed from %1:cloud and cannot be restored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log in to %1:cloud in order to connect to %1:core systems from anywhere.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to connect to the login server. Please mase sure your network connection is working.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unexpected error happened. Please report this isse. Error code:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CloudSettingsPage</name>
+    <message>
+        <source>Cloud settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can connect a nymea:box to a nymea:cloud in order to access it from anywhere</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloud connection enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This box is not connected to %1:cloud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Registering box in %1:cloud...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This box is not configured to connect to %1:cloud.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting the box to %1:cloud...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The box is connected to %1:cloud.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This box is not configured to access the %1:cloud. In order for a box to connect to %1:cloud it needs to be registered first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log in to cloud</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ComposeEventDescriptorPage</name>
+    <message>
+        <source>Select event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A specific thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A group of things</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureThingPage</name>
+    <message>
+        <source>Delete Thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename Thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reconfigure Thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vendor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectPage</name>
+    <message>
+        <source>Connect %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Demo mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oh, look!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Just a moment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uh oh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start wireless setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloud login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Demo mode (online)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not the ones you&apos;re looking for? We&apos;re looking for more!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Box information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Available connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are %1 %2:cores in your network! Which one would you like to use?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>We haven&apos;t found a %1:core in your network yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There doesn&apos;t seem to be a %1:core installed in your network. Please make sure your %1:core system is correctly set up and connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching for %1:core systems...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you have a %1:core but it&apos;s not connected to your network yet? Use the wireless setup to connect it!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectWiFiPage</name>
+    <message>
+        <source>Select wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter the password for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, the password is wrong. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting the %1:core to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectingPage</name>
+    <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The network connection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems you&apos;re not connected to the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The host has rejected our connection. This probably means that %1 is not running on this host. Perhaps it&apos;s restarting?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1:core has closed the connection. This probably means it has been turned off or restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1:core did not respond. Please make sure your network connection works properly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unrecovareable SSL Error happened. Please make sure certificates are installed correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The SSL Certificate is not trusted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown error happened. We&apos;re very sorry for that.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1:core could not be found on this address. Please make sure you entered the address correctly and that the system is powered on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionInterfaceDelegate</name>
+    <message>
+        <source>Interface: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Any</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>localhost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionInterfacesPage</name>
+    <message>
+        <source>Connection interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TCP server interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebSocket server interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeveloperOptionsPage</name>
+    <message>
+        <source>Developer options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloud environment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable app logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Experience mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeveloperTools</name>
+    <message>
+        <source>Developer tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Debug server enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to access the debug interface, please enable the web server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The web server cannot be reached on %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please enable the web server to be accessed on this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open debug interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBrowserPage</name>
+    <message>
+        <source>Browse %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceLogPage</name>
+    <message>
+        <source>History for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter by</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DevicePageBase</name>
+    <message>
+        <source>Magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark as favorite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing is not connected!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing runs out of battery!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceRulesPage</name>
+    <message>
+        <source>Magic involving %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There&apos;s no magic involving %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add some using the wizard stick!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DevicesPageDelegate</name>
+    <message>
+        <source>All off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 open</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DoorbellDevicePage</name>
+    <message>
+        <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditCalendarItemPage</name>
+    <message>
+        <source>Pick a time frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Feb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>May</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jul</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Nov</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dez</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hourly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>daily</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>weekly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>monthly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yearly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weekdays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Day of month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditRulePage</name>
+    <message>
+        <source>Add new magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Any changes to the rule will be lost.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This rule is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Execute actions when something happens.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When any of these events happen...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples:
+• When a button is pressed...
+• When the temperature changes...
+• At 7 am...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configure...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add another...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do something while a condition is met.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...but only if those conditions are met...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When this condition...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples:
+• While I&apos;m at home...
+• When the temperature is below 0...
+• Between 9 am and 6 pm...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When time is in...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...during this time...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a scene.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...come true, execute those actions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...comes true, execute those actions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...execute those actions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Just pick some actions which will be executed when the scene is activated. Scenes are like any other magic except they can also be activated manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add an action...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add another action...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...isn&apos;t met any more, execute those actions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If the condition isn&apos;t met, execute those actions instead:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When one of my things triggers an event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When a thing of a given type triggers an event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At a particular time or date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add condition...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When one of my things is in a certain state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When a thing of a given type enters a state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>During a given time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add action...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Execute an action on one of my things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Execute an action on an entire kind of things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is a scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditStateEvaluatorPage</name>
+    <message>
+        <source>Conditions</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditThingsPage</name>
+    <message>
+        <source>Configure Things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no things set up yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order for your %1 system to be useful, go ahead and add some things.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditTimeEventItemPage</name>
+    <message>
+        <source>Pick a time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hourly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>daily</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>weekly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>monthly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yearly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Feb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>May</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jul</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Nov</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dez</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weekdays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Day of month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ErrorDialog</name>
+    <message>
+        <source>Oh snap!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unexpected error happened. We&apos;re sorry for that.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EventDescriptorDelegate</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FancyHeader</name>
+    <message>
+        <source>Menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FingerprintReaderDevicePage</name>
+    <message>
+        <source>Manage access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access log:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access granted for user %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access denied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manage users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no fingerprints registered with this lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The following users have valid fingerprints for this lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a new fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left thumb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left index finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left middle finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left ring finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left pinky finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Right thumb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Right index finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Right middle finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Right ring finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Right pinky finger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please scan the fingerprint now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uh oh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All done!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fingerprint could not be read.
+Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fingerprint added!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access request details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date/Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GarageDeviceListPage</name>
+    <message>
+        <source>Garage gates</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettingsPage</name>
+    <message>
+        <source>Box settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reboot %1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutdown %1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reboot your %1:core sytem now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to shut down your %1:core sytem now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shut down %1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GenericDeviceListPage</name>
+    <message>
+        <source>My %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All my things</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GenericDevicePage</name>
+    <message>
+        <source>States</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GenericTypeGraph</name>
+    <message>
+        <source>%1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 weeks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 months</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GenericTypeGraphPre110</name>
+    <message>
+        <source>6 h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>24 h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>7 d</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Graph</name>
+    <message>
+        <source>Sorry, there isn&apos;t enough data to display a graph here yet!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>HeatingDevicePage</name>
+    <message>
+        <source>Boost</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Imprint</name>
+    <message>
+        <source>Developer options are now enabled. If you have found this by accident, it is most likely not of any use for you. It will just enable some nerdy developer gibberish in the app. Tap the icon another 10 times to disable it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Developer options are now disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Howdy cowboy!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nymea is a registered trademark of guh GmbH.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Licensed under the terms of the GNU general public license, version 2. Please visit the GitHub page for source code and build instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visit the nymea website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visit GitHub page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View license text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Qt is a registered trademark of The Qt Company Ltd. and its subsidiaries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visit the Qt website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License text</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Interfaces</name>
+    <message>
+        <source>Battery powered devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Battery level is critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Battery level entered critical state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notification services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message body</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light is turned on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A light is turned on or off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn lights on or off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature has changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Closable things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Powered things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing is turned on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A thing is turned on or off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn things on or off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dimmable lights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light&apos;s brightness is</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A light&apos;s brightness has changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set lights brightness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Presence sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is present</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Presence changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blinds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Awnings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Garage gates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Air sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Air quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Air quality changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humidity sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humidity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humidity changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Daylight sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Daylight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Daylight changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EV charger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable charging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speakers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateways</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Heatings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Heating enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Heating enabled changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable heating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback status changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set playback status</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LightsDeviceListPage</name>
+    <message>
+        <source>Lights</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogViewerPage</name>
+    <message>
+        <source>Log viewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rule triggered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actions executed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rule active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rule inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exit actions executed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabled changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LoginPage</name>
+    <message>
+        <source>Welcome to %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, that wasn&apos;t right. Try again please.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The email you&apos;ve entered isn&apos;t valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The email you&apos;ve entered is already used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password you&apos;ve chose is too weak.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to use your %1 system, please log in.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your e-mail address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error happened with the user storage. Please make sure your %1:core system is installed correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to use your %1 system, please enter your email address and set a password for it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LookAndFeelSettingsPage</name>
+    <message>
+        <source>Look and feel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return to home on idle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show connection tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application needs to be restarted for style changes to take effect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn screen off when idle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen off timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen brightness</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MagicPage</name>
+    <message>
+        <source>Magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no magic set up yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use magic to make your things smart! In a few easy steps you&apos;ll have your things wired up and work for you.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add some magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Main</name>
+    <message>
+        <source>Garage gates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no garage gates set up yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Celsi°s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no drexel und weiss heating system set up yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current air quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature, °C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automate this thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Party</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <source>Configure things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scenes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no favorite things yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It appears there are no things set up either yet. In order to use favorites you need to add some things first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Favorites allow you to keep track of your most important things when you have lots of them. Watch out for the star when interacting with things and use it to mark them as your favorites.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Welcome to %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no things set up yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My scenes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are no scenes set up yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It appears there are no things set up either yet. In order to use scenes you need to add some things first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scenes provide a useful way to control your things with just one click.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a scene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System update in progress...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n system update(s) available</source>
+        <translation type="unfinished">
+            <numerusform>%n system update available</numerusform>
+            <numerusform>%n system updates available</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>System settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order for your %1 system to be useful, go ahead and add some things.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ManualConnectPage</name>
+    <message>
+        <source>Manual connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TCP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Websocket</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Encrypted connection:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MediaDeviceListPage</name>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No playback</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MediaDevicePage</name>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MqttBrokerSettingsPage</name>
+    <message>
+        <source>MQTT broker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MQTT Server Interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MQTT permissions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Client ID: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MqttPolicyPage</name>
+    <message>
+        <source>Mqtt permission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Client ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E.g. Sensor_1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 is already used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t be blank</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allowed publish topics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allowed subscribe filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkSettingsPage</name>
+    <message>
+        <source>Network settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Networking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trigger a wireless scan on the device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmanaged</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deactivating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preparing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Setting IP configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checking IP configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondaries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current connection state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnecting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locally connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Site connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Globally connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Networking enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable networking altogether</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable networking?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wired network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shows the current ethernet status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plugged in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unplugged</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable WiFi?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WiFi networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter the password for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MAC Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Signal strength</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabling networking will disconnect all connected clients. Be aware that you will not be able to interact remotely with this %1 system any more. Do not proceed unless you know what your are doing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabling WiFi will disconnect all clients connected via WiFi. Be aware that you will not be able to interact remotely with this %1 system any more unless a LAN cable is connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewMagicPage</name>
+    <message>
+        <source>New magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewThingMagicPage</name>
+    <message>
+        <source>New magic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create some magic manually</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New magic for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewThingPage</name>
+    <message>
+        <source>Set up new thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotificationsDevicePage</name>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sent notifications:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notification details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotificationsView</name>
+    <message>
+        <source>Send a notification now:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Nymea</name>
+    <message>
+        <source>Lighting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weather</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateways</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humidity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Noise level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CO2 level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming Events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shutters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blinds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Awnings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Garage gates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smart meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Heatings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EV-chargers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power sockets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uncategorized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>sensor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>battery powered thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>connectable thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>switchable thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>daylight sensor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>presence sensor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Doorbells</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>doorbell</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>alert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>access control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>smart meter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>media player</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NymeaConnection</name>
+    <message>
+        <source>Common Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oragnisation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oragnisational Unit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Country:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ParamDescriptorDelegate</name>
+    <message>
+        <source>is</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is not</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is greater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is smaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is greater or equal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is smaller or equal</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PasswordTextField</name>
+    <message>
+        <source>Pick a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginParamsPage</name>
+    <message>
+        <source>%1 settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginsPage</name>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This list shows the list of installed plugins on this %1 system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PowerSocketsDeviceListPage</name>
+    <message>
+        <source>My %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PushButtonAuthPage</name>
+    <message>
+        <source>Welcome to %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, something went wrong during the setup. Try again please.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authentication required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please press the button on your %1 box to authenticate this device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RemoveDeviceMethodDialog</name>
+    <message>
+        <source>This thing is currently used in one or more rules:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all those rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update rules, removing this thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t remove this thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RootItem</name>
+    <message>
+        <source>Connection error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, the version of the %1:core you are trying to connect to is too old. This app requires at least version %2 but this %1:core only supports %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RuleActionDelegate</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>value from event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown item</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>S:</name>
+    <message>
+        <source></source>
+        <comment>example: &quot;and temperature &gt; 5&quot;</comment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Confirm password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;font color=&quot;%1&quot;&gt;The passwords match.&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;font color=&quot;%1&quot;&gt;The passwords &lt;/font&gt;&lt;font color=&quot;%2&quot;&gt;do not&lt;/font&gt;&lt;font color=&quot;%1&quot;&gt; match.&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>only if %1 %2 %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>and %1 %2 %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;font color=&quot;%1&quot;&gt;The password needs to be &lt;/font&gt;&lt;font color=&quot;%2&quot;&gt;at least %3 characters long&lt;/font&gt;&lt;font color=&quot;%1&quot;&gt;, contain &lt;/font&gt;&lt;font color=&quot;%4&quot;&gt;lowercase&lt;/font&gt;&lt;font color=&quot;%1&quot;&gt;, &lt;/font&gt;&lt;font color=&quot;%5&quot;&gt;uppercase&lt;/font&gt;&lt;font color=&quot;%1&quot;&gt; letters as well as &lt;/font&gt;&lt;font color=&quot;%6&quot;&gt;numbers&lt;/font&gt;&lt;font color=&quot;%1&quot;&gt; and &lt;/font&gt;&lt;font color=&quot;%7&quot;&gt;special characters&lt;/font&gt;&lt;font color=&quot;%1&quot;&gt;.&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectActionPage</name>
+    <message>
+        <source>Switch lights...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Control media playback...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute media playback...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify me...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manually configure an action...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>params</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch lights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set selected lights power to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notification text</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectBrowserItemActionPage</name>
+    <message>
+        <source>Select item</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectEventDescriptorParamsPage</name>
+    <message>
+        <source>Only consider event if</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectRuleActionPage</name>
+    <message>
+        <source>Open an item on this thing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectRuleActionParamsPage</name>
+    <message>
+        <source>Use static value as parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use event parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use a thing&apos;s state value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert value here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a state</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectStateDescriptorParamsPage</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectStatePage</name>
+    <message>
+        <source>Select state</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectThingPage</name>
+    <message>
+        <source>Select a kind of things</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select a thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Any %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SensorDevicePagePost110</name>
+    <message>
+        <source>Last seen:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sunrise:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sunset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SensorView</name>
+    <message>
+        <source>6 h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>24 h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>7 d</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SensorsDeviceListPage</name>
+    <message>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is open</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ServerConfigurationDialog</name>
+    <message>
+        <source>Server configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Any</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Localhost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSL enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Login required</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsPage</name>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change system name and time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log viewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View system log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>API interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MQTT broker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configure the MQTT broker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Web server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configure the web server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>List and cofigure installed plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Developer tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access tools for debugging and error reporting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About %1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find server UUID and versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update your %1:core system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Networking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configure the system&apos;s network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect this %1:core to %1:cloud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configure how clients interact with this system</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SetupWizard</name>
+    <message>
+        <source>Set up thing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add thing manually</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching for things...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No things of this kind could be found...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make sure your things are set up and connected, try searching again or go back and pick a different kind of thing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name the thing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pairing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing reconfigured!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thing added!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uh oh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All done. You can now start using %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Something went wrong setting up this thing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Welcome to %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This %1 system has not been set up yet. This wizard will guide you through a few simple steps to set it up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShutterDeviceListPage</name>
+    <message>
+        <source>Shutters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SimpleStateEvaluatorDelegate</name>
+    <message>
+        <source>Press to edit condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1: %2 %3 %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SmartMeterDeviceListPage</name>
+    <message>
+        <source>Smart meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StateEvaluatorDelegate</name>
+    <message>
+        <source>and all of those</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>or any of those</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit condition...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When one of my things is in a certain state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When a thing of a given type enters a state</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StateLogPage</name>
+    <message>
+        <source>History for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Graph</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SystemUpdatePage</name>
+    <message>
+        <source>System update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is up to date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will start a system update. Note that the update might take several minutes and your %1:core might not be functioning properly during this time and restart during the process.
+Do you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configure update sources</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabling additional software sources allows to install unreleased %1:core packages.
+This can potentially break your system and lead to problems.
+Please only use this if you are sure you want this and consider reporting the issues you find when testing unreleased channels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable package source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Installed version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Candidate version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checking for updates...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check for updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n update(s) available</source>
+        <translation type="unfinished">
+            <numerusform>%n update available</numerusform>
+            <numerusform>%n updates available</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Check again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Install or remove software</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Package information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will start a system update. Note that the update might take several minutes and your %1:core might not be functioning properly or restart during this time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+Do you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimeEventDelegate</name>
+    <message>
+        <source>At %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>repeated %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hourly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>daily</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fri</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>weekly on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>monthly on the %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>every year</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateRunningOverlay</name>
+    <message>
+        <source>System update in progress...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system may restart in order to complete the update. %1:app will reconnect automatically after the update.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WeatherDeviceListPage</name>
+    <message>
+        <source>Weather</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WeatherView</name>
+    <message>
+        <source>N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>W</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NW</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WebServerConfigurationDialog</name>
+    <message>
+        <source>Server configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Any</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Localhost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSL enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Login required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Public folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WebServerSettingsPage</name>
+    <message>
+        <source>Web server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Web server interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WirelessSetupManager</name>
+    <message>
+        <source>Invalid value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no networkmanager available on the device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no wireless device available on the device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid parameters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The wireless networking is disabled on the device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The networking is disabled on the device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown error occured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WirelessSetupPage</name>
+    <message>
+        <source>Wireless network setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close wireless setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your %1:core is connected to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for the %1:core to appear in your network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect to %1:core</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for accesscontroltemplates</name>
+    <message>
+        <source>Alert me on denied access attempts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify my about access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify my about user access</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for buttontemplates</name>
+    <message>
+        <source>Turn on a light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off a light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch a light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off all lights</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for daylightsensor</name>
+    <message>
+        <source>Turn on a light while it&apos;s dark outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on a light when it gets dark outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on all lights when it gets dark outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for doorbellruletemplates</name>
+    <message>
+        <source>Alert on doorbell ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for mediatemplates</name>
+    <message>
+        <source>Dim light while watching TV</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for notificationtemplates</name>
+    <message>
+        <source>Notify me when a device runs out of battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify me when something runs dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify me when a thing gets disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify me when a thing connects</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for presencesensortemplates</name>
+    <message>
+        <source>Turn on something while being present</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off something when leaving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off everything when leaving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off all lights when leaving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on something when arriving</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for smartmetertemplates</name>
+    <message>
+        <source>Charge my car while producing energy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on heating while producing energy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>description for thermostattemplates</name>
+    <message>
+        <source>Set temperature while I&apos;m home</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for accesscontroltemplates</name>
+    <message>
+        <source>Denied access attempt on %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access granted on %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access granted to user on %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for buttontemplates</name>
+    <message>
+        <source>%0 turns on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%0 turns off %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%0 switches %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off everything with %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for daylightsensor</name>
+    <message>
+        <source>Turn on %1 while it&apos;s dark outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on %1 when it gets dark outside (%0)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on all lights when it gets dark outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for doorbellruletemplates</name>
+    <message>
+        <source>Alert %1 when someone is at %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for mediatemplates</name>
+    <message>
+        <source>%0 dims %1 for movie time</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for notificationtemplates</name>
+    <message>
+        <source>Low battery alert for %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify %1 when %0 runs dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect alert for %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connection notification for %0</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for presencesensortemplates</name>
+    <message>
+        <source>Turn on %1 while %0 reports presence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off %1 when %0 reports leaving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off everything when %0 reports leaving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn off all lights when %0 reports leaving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on %1 when %0 reports arriving</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for smartmetertemplates</name>
+    <message>
+        <source>Smart car charging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smart heating</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for template</name>
+    <message>
+        <source>%0 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ruleNameTemplate for thermostattemplates</name>
+    <message>
+        <source>Set temperature while I&apos;m home</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
This will prefer "en" that over, say, "de" in case of locale settings like
primary: "en_AT"
secondary: "de_AT"

In such cases we still want english, not german.

Fixes #232