### PR TITLE
Fix session startup scripts to work on buster

### DIFF
--- a/packaging/linux-common/nymea-app-kiosk.desktop
+++ b/packaging/linux-common/nymea-app-kiosk.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=XSession
-Exec=/usr/bin/openbox --startup /usr/bin/nymea-app-kiosk-wrapper
+Exec=/usr/bin/nymea-app-session
 DesktopNames=nymea:app
 

--- a/packaging/linux-common/nymea-app-session
+++ b/packaging/linux-common/nymea-app-session
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/openbox --startup /usr/bin/nymea-app-kiosk-wrapper

--- a/packaging/ubuntu/debian/nymea-app-kiosk.install
+++ b/packaging/ubuntu/debian/nymea-app-kiosk.install
@@ -1,4 +1,5 @@
 packaging/linux-common/nymea-app-kiosk.desktop /usr/share/xsessions/
 packaging/linux-common/lightdm/60-nymea-app-kiosk.conf /usr/share/lightdm/lightdm.conf.d/
 packaging/linux-common/nymea-app-kiosk-wrapper /usr/bin/
+packaging/linux-common/nymea-app-session /usr/bin/
 packaging/linux-common/udev/90-pi-backlight.rules /lib/udev/rules.d/


### PR DESCRIPTION
Apparently the session Exec line can't have arguments any more