### PR TITLE
Update android packaging to support Qt 5.14

### DIFF
--- a/libnymea-app/libnymea-app.pro
+++ b/libnymea-app/libnymea-app.pro
@@ -283,3 +283,8 @@ HEADERS += \
 ubports: {
     DEFINES += UBPORTS
 }
+
+# https://bugreports.qt.io/browse/QTBUG-83165
+android: {
+    DESTDIR = $${ANDROID_TARGET_ARCH}
+}

--- a/nymea-app/nymea-app.pro
+++ b/nymea-app/nymea-app.pro
@@ -77,6 +77,8 @@ android {
         $$ANDROID_PACKAGE_SOURCE_DIR/src/io/guh/nymeaapp/NymeaAppNotificationService.java \
         $$ANDROID_PACKAGE_SOURCE_DIR/LICENSE
 
+    # https://bugreports.qt.io/browse/QTBUG-83165
+    LIBS += -L$${top_builddir}/libnymea-app/$${ANDROID_TARGET_ARCH}
 }
 
 macx: {

--- a/packaging/android/AndroidManifest.xml
+++ b/packaging/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <manifest package="io.guh.nymeaapp" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.0" android:versionCode="1" android:installLocation="auto">
 
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="nymea:app" android:icon="@mipmap/icon" android:roundIcon="@mipmap/round_icon">
-        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="io.guh.nymeaapp.NymeaAppActivity" android:label="nymea:app" android:screenOrientation="unspecified" android:launchMode="singleTop" android:theme="@style/SplashScreenTheme">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="nymea:app" android:icon="@mipmap/icon" android:roundIcon="@mipmap/round_icon" android:extractNativeLibs="true">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:name="io.guh.nymeaapp.NymeaAppActivity" android:label="nymea:app" android:screenOrientation="unspecified" android:launchMode="singleTop" android:theme="@style/SplashScreenTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -24,7 +24,7 @@
             <!-- Run with local libs -->
             <meta-data android:name="android.app.use_local_qt_libs" android:value="-- %%USE_LOCAL_QT_LIBS%% --"/>
             <meta-data android:name="android.app.libs_prefix" android:value="/data/local/tmp/qt/"/>
-            <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
+            <meta-data android:name="android.app.load_local_libs_resource_id" android:resource="@array/load_local_libs"/>
             <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
             <!--  Messages maps -->

--- a/packaging/android/build.gradle
+++ b/packaging/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.google.gms:google-services:3.2.0'
     }
 }

--- a/packaging/android/build.gradle
+++ b/packaging/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath 'com.google.gms:google-services:3.2.0'
     }
 }

--- a/packaging/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packaging/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/packaging/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packaging/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip

--- a/packaging/android/res/values/libs.xml
+++ b/packaging/android/res/values/libs.xml
@@ -22,4 +22,8 @@
         <!-- %%INSERT_BUNDLED_IN_ASSETS%% -->
     </array>
 
+    <array name="load_local_libs">
+        <!-- %%INSERT_LOCAL_LIBS%% -->
+    </array>
+
 </resources>


### PR DESCRIPTION
Not working yet due to bugs in Qt 5.14:

Broken fallback style on android:
https://bugreports.qt.io/browse/QTBUG-81216

In order to switch to the new android AAB packages, this needs to be resolved (Qt 5.14.1)
https://bugreports.qt.io/browse/QTBUG-80351

And likely this:
https://bugreports.qt.io/browse/QTBUG-80406

