### PR TITLE
Revert "Fix the app bundle name in the macOS installer."

### DIFF
--- a/nymea-app.pro
+++ b/nymea-app.pro
@@ -51,9 +51,7 @@ QMAKE_EXTRA_TARGETS += wininstaller
 
 # OS X installer bundle
 # Install XCode and Qt clang64, add qmake directory to PATH
-# run "make osxbundle" or "make osxinstaller"
-# Note: Our target is "nymea-app" but we want it to show up as "nymea:app" so we need to rename
-# the app bundle in the last steps because not all tools deal well with the ":" if we rename in earlier steps.
+# run "make osxbundle"
 # Note: We're dropping the QtWebEngineCore framework manually, as that's not app store compliant
 # and we're using the WebView instead anyways. (IMHO a bug that macdeployqt -appstore-compliant even adds it)
 osxbundle.depends = nymea-app
@@ -74,8 +72,7 @@ QMAKE_EXTRA_TARGETS += osxbundle
 # Create a .pkg osx installer.
 osxinstaller.depends = osxbundle
 osxinstaller.commands += cd nymea-app &&
-osxinstaller.commands += cp -R nymea-app.app nymea\:app.app &&
-osxinstaller.commands += productbuild --component nymea\:app.app /Applications ../nymea-app-$${APP_VERSION}.pkg && cd .. &&
+osxinstaller.commands += productbuild --component nymea-app.app /Applications ../nymea-app-$${APP_VERSION}.pkg && cd .. &&
 osxinstaller.commands += productsign -s \"3rd Party Mac Developer Installer\" nymea-app-$${APP_VERSION}.pkg nymea-app-signed-$${APP_VERSION}.pkg
 QMAKE_EXTRA_TARGETS += osxinstaller
 


### PR DESCRIPTION
This reverts commit bc0b9511392d8817e306ea5ae30a19ce9477cfcc.

For some reason, when uploading to the mac app store, : is not allowed in bundle names... We'll keep it to - then...

Sadly, this implies closing #318 as "wontfix"