### PR TITLE
Fix adaptive icon on "round" launchers

### DIFF
--- a/packaging/android/res/mipmap-anydpi-v26/round_icon.xml
+++ b/packaging/android/res/mipmap-anydpi-v26/round_icon.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@color/icon_background"/>
+  <foreground android:drawable="@drawable/icon_foreground"/>
+</adaptive-icon>


### PR DESCRIPTION
We use a android:roundIcon for bckwards compatibility with android < 8.
This caused the adaptive icon to not be used on round icon launchers.
This branch just copies the regular adaptive icon xml to a round one.

Once we don't support android < 8 any more we can completely drop
the roundIcon stuff as the normal adaptive icon works just fine
for round launchers unless you use android:roundIcon in the xml.