### PR TITLE
Fix encryption flag erraneously set for "ws" connections

### DIFF
--- a/libnymea-app/connection/nymeaconnection.cpp
+++ b/libnymea-app/connection/nymeaconnection.cpp
@@ -250,7 +250,7 @@ void NymeaConnection::onConnected()
     NymeaTransportInterface* newTransport = qobject_cast<NymeaTransportInterface*>(sender());
     if (!m_currentTransport) {
         m_currentTransport = newTransport;
-        qDebug() << "NymeaConnection: Connected to" << m_currentHost->name() << "via" << m_currentTransport->url();
+        qDebug() << "NymeaConnection: Connected to" << m_currentHost->name() << "via" << m_currentTransport->url() << m_currentTransport->isEncrypted();
         emit currentConnectionChanged();
         emit connectedChanged(true);
         return;

--- a/libnymea-app/connection/websockettransport.cpp
+++ b/libnymea-app/connection/websockettransport.cpp
@@ -101,7 +101,7 @@ void WebsocketTransport::ignoreSslErrors(const QList<QSslError> &errors)
 
 bool WebsocketTransport::isEncrypted() const
 {
-    return !m_socket->sslConfiguration().isNull();
+    return m_url.scheme() == "wss";
 }
 
 QSslCertificate WebsocketTransport::serverCertificate() const

--- a/libnymea-app/jsonrpc/jsonrpcclient.cpp
+++ b/libnymea-app/jsonrpc/jsonrpcclient.cpp
@@ -665,14 +665,15 @@ void JsonRpcClient::helloReply(int /*commandId*/, const QVariantMap &params)
             if (m_connection->sslCertificate().toPem() != pem) {
                 // Uh oh, the certificate has changed
                 qWarning() << "This connections certificate has changed!";
-
-                QSslCertificate certificate = m_connection->sslCertificate();
-                QVariantMap issuerInfo = certificateIssuerInfo();
-                emit verifyConnectionCertificate(m_serverUuid, issuerInfo, certificate.toPem());
+                qWarning() << "Old PEM:" << pem;
+                qWarning() << "New PEM:" << m_connection->sslCertificate().toPem();
 
                 // Reject the connection until the UI explicitly accepts this...
                 m_connection->disconnectFromHost();
 
+                QSslCertificate certificate = m_connection->sslCertificate();
+                QVariantMap issuerInfo = certificateIssuerInfo();
+                emit verifyConnectionCertificate(m_serverUuid, issuerInfo, certificate.toPem());
                 return;
             }
             qDebug() << "This connections certificate is trusted.";


### PR DESCRIPTION
This could cause the client to think that there is a certificate
mismatch if there is a pinned certificate for this host already
and we then connect to an unecrypted ws socket.

Also, disconnect clients before raising the certificate mismatch
error in case a client implementation would just ignore this
and reconnect syncronously right way.