### PR TITLE
[snap] add daemon mode

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,52 @@
+name: Snap
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  Snap:
+    runs-on: ubuntu-latest
+
+    env:
+      SNAPCRAFT_BUILD_INFO: 1
+
+    timeout-minutes: 60
+    steps:
+    - name: Install Snapcraft
+      uses: Saviq/action-snapcraft@add-channel
+      with:
+        channel: candidate
+        use_lxd: true
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        # Needed for version determination to work
+        fetch-depth: 0
+
+    - name: Build
+      run: |
+        # Build the parts.
+        sg lxd -c '/snap/bin/snapcraft build --use-lxd'
+    - name: Build and verify the snap
+      id: build-snap
+      env:
+        SNAP_ENFORCE_RESQUASHFS: 0
+      run: |
+        # Actually build the snap.
+        sg lxd -c '/snap/bin/snapcraft --use-lxd'
+        sudo snap install review-tools
+        /snap/bin/review-tools.snap-review *.snap
+        echo "::set-output name=snap-file::$( ls *.snap )"
+    - name: Upload the snap
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.build-snap.outputs.snap-file }}
+        path: ${{ steps.build-snap.outputs.snap-file }}
+        if-no-files-found: error

--- a/packaging/ubuntu/snap/hooks/configure
+++ b/packaging/ubuntu/snap/hooks/configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl restart $SNAP_NAME

--- a/packaging/ubuntu/snap/snapcraft.yaml
+++ b/packaging/ubuntu/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: nymea-app
-version: developer-build
 summary: Control app for nymea
 description: | 
   The nymea daemon is a plugin based IoT (Internet of Things) server. 
@@ -9,12 +8,19 @@ description: |
   scenes and behaviors for your environment.
 
 grade: stable
-base: core18
+base: core20
 confinement: strict
+adopt-info: nymea-app
+
+architectures:
+- build-on: amd64
+- build-on: arm64
+- build-on: armhf
 
 apps:
   nymea-app:
-    command: desktop-launch nymea-app
+    command-chain: [ bin/desktop-launch ]
+    command: usr/bin/nymea-app
     desktop: usr/share/applications/nymea-app.desktop
     plugs:
     - avahi-observe
@@ -55,7 +61,6 @@ parts:
     plugin: qmake
     source: .
     after: [desktop-qt5]
-    project-files: [ nymea-app.pro ]
     build-packages:
       - execstack
       - qt5-default
@@ -90,3 +95,6 @@ parts:
       - libavahi-common3
       - qtvirtualkeyboard-plugin
       - qtwayland5
+    override-build: |
+      snapcraftctl set-version $( git -C ${SNAPCRAFT_PART_SRC} describe --tags )
+      snapcraftctl build

--- a/packaging/ubuntu/snap/snapcraft.yaml
+++ b/packaging/ubuntu/snap/snapcraft.yaml
@@ -18,6 +18,23 @@ architectures:
 - build-on: armhf
 
 apps:
+  daemon:
+    daemon: simple
+    environment:
+      QT_IM_MODULE: qtvirtualkeyboard
+    restart-condition: always
+    command-chain:
+      - bin/run-daemon
+      - bin/desktop-launch
+      - bin/wayland-launch
+    command: usr/bin/nymea-app --kiosk
+    plugs:
+    - avahi-observe
+    - bluez
+    - network
+    - opengl
+    - wayland
+
   nymea-app:
     command-chain: [ bin/desktop-launch ]
     command: usr/bin/nymea-app
@@ -56,6 +73,14 @@ parts:
       - locales-all
       - xdg-user-dirs
       - fcitx-frontend-qt5
+
+  mir-kiosk-snap-launch:
+    plugin: dump
+    source: https://github.com/MirServer/mir-kiosk-snap-launch.git
+    override-build: |
+      ${SNAPCRAFT_PART_BUILD}/build-with-plugs.sh opengl wayland
+    stage-packages:
+      - inotify-tools
 
   nymea-app:
     plugin: qmake

--- a/snap
+++ b/snap
@@ -1,0 +1,1 @@
+packaging/ubuntu/snap


### PR DESCRIPTION
This adds a daemon/kiosk mode to nymea-app, through a `snap set nymea-app daemon=true` setting.

It only defaults to true on [Ubuntu Core](https://ubuntu.com/core) devices, so getting a nymea appliance off a [Pi with Ubuntu Core](https://ubuntu.com/download/raspberry-pi-core) is as simple as:
```bash
$ snap install mir-kiosk nymea-app
```

You may as well `snap install nymea` itself, too.

To get additional functionality like auto discovery, you will need to `snap install avahi && snap connect nymea-app:avahi-observe avahi && snap restart nymea-app`