### PR TITLE
Immediately delete a disconnected transport

### DIFF
--- a/libnymea-app/connection/nymeaconnection.cpp
+++ b/libnymea-app/connection/nymeaconnection.cpp
@@ -312,7 +312,7 @@ void NymeaConnection::onDisconnected()
         return;
     }
     m_transportCandidates.remove(m_currentTransport);
-    m_currentTransport->deleteLater();
+    delete m_currentTransport;
     m_currentTransport = nullptr;
 
     foreach (NymeaTransportInterface *candidate, m_transportCandidates.keys()) {


### PR DESCRIPTION
to prevent the app from processing obsolete events that may still process from socket input buffers after a disconnect event.

This may cause several seconds of processing state change notifications when resuming the app after it is suspended on a mobile OS.