### PR TITLE
Fix the snap package on Wayland

### DIFF
--- a/packaging/ubuntu/snap/snapcraft.yaml
+++ b/packaging/ubuntu/snap/snapcraft.yaml
@@ -41,6 +41,8 @@ apps:
     - wayland
 
   nymea-app:
+    environment:
+      WAYLAND_DISPLAY: wayland-99
     command-chain: [ bin/desktop-launch ]
     command: usr/bin/nymea-app
     desktop: usr/share/applications/nymea-app.desktop


### PR DESCRIPTION
Fixes this error message:
`Failed to create wl_display (Permission denied)`

Closes #690