### PR TITLE
Fix frequent reconnects on iOS

### DIFF
--- a/libnymea-app/connection/nymeaconnection.h
+++ b/libnymea-app/connection/nymeaconnection.h
@@ -141,6 +141,10 @@ private:
     Connection *m_preferredConnection = nullptr;
 
     QTimer m_reconnectTimer;
+
+#ifdef Q_OS_IOS
+    NymeaConnection::BearerType m_usedBearerType;
+#endif
 };
 
 #endif // NYMEACONNECTION_H


### PR DESCRIPTION
Tries to guess the used bearer type on iOS and only reconnect if that one changes.