### PR TITLE
add build folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Thumbs.db
 *.pro.user*
 
 packaging/android/nymeaapp.properties
+build


### PR DESCRIPTION
When building the app with clickable it does create a build folder. This will be listed as git changes. Adding the build folder to .gitignore leaves that out.